### PR TITLE
MINOR: If the fakedatabase file doesn't exist, throw an error.

### DIFF
--- a/src/FakeDatabase.php
+++ b/src/FakeDatabase.php
@@ -36,6 +36,10 @@ class FakeDatabase
      */
     protected function getData()
     {
+        if (!file_exists($this->path)) {
+            throw new LogicException(sprintf('FakeDatabase at %s no longer exists', $this->path));
+        }
+
         if (file_exists($this->path) && !is_readable($this->path)) {
             throw new LogicException(sprintf('FakeDatabase at %s is not readable', $this->path));
         }

--- a/tests/FakeDatabaseTest.php
+++ b/tests/FakeDatabaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Chillu\FakeDatabase\Tests;
 
+use Exception;
 use \LogicException;
 use Chillu\FakeDatabase\FakeDatabase;
 use Chillu\FakeDatabase\FakeObject;
@@ -14,7 +15,7 @@ class FakeDatabaseTest extends TestCase
 
     /** @var FakeDatabase */
     protected $db;
-    
+
     /** @var string */
     protected $path;
 
@@ -59,23 +60,27 @@ class FakeDatabaseTest extends TestCase
             )
         ));
         $this->db->update('FakeDatabaseTest_Object', 'id1', $objIn);
-        
+
         $objOut = $this->db->get('FakeDatabaseTest_Object', 'id1');
         $this->assertInstanceOf(FakeDBTestObject::class, $objOut);
         $this->assertEquals($objOut->foo, 'newbar', 'Updates existing toplevel values');
         $this->assertEquals($objOut->nested->bar, null, 'Nulls nested values');
         $this->assertEquals($objOut->nested->new, 'newval', 'Inserts new nested values');
-        
+
         $this->db->update('TypeThatDoesNotExist', 'DummyKey', $fakeObj = new FakeObject());
         $this->assertEquals($fakeObj, $this->db->get('TypeThatDoesNotExist', 'DummyKey'));
     }
 
     public function testReset()
     {
+        $dbPath = $this->db->getPath();
         $objIn = new FakeDBTestObject(array('foo' => 'bar'));
         $this->db->set('FakeDatabaseTest_Object', 'id1', $objIn);
         $this->db->reset();
-        $this->assertNull($this->db->get('FakeDatabaseTest_Object', 'id1'));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('FakeDatabase at %s no longer exists', $dbPath));
+        $this->db->get('FakeDatabaseTest_Object', 'id1'); // Should throw the exception
     }
 
     public function testToArray()
@@ -96,19 +101,19 @@ class FakeDatabaseTest extends TestCase
                 ]
             ]
         ];
-        
+
         $this->db->set('obj', 'obj1', new FakeDBTestObject(array('foo' => 'bar')));
         $this->db->set('otherobj', 'obj2', new FakeDBTestOtherObject(array('foo' => 'bar')));
         $this->assertEquals($expected, $this->db->toArray());
         $this->assertEquals([0 => $this->db->get('obj', 'obj1')], $this->db->getAll('obj'));
     }
-    
+
     public function testGetPath()
     {
         $this->assertEquals($this->path, $this->db->getPath());
         $this->assertFileExists($this->path);
     }
-    
+
     public function testFindWithoutType()
     {
         $this->assertSame(false, $this->db->find('InvalidType', 'key', 'value'));
@@ -128,7 +133,7 @@ class FakeDatabaseTest extends TestCase
             'bar',
             $match->array['foo']
         );
-        
+
         $this->assertEquals(null, $this->db->find('mytype', 'unknownpart.foo', 'bar'));
     }
 
@@ -138,7 +143,7 @@ class FakeDatabaseTest extends TestCase
         chmod($this->db->getPath(), '200');
         $data = $this->db->get('DummyType', 'DummyKey');
     }
-    
+
     public function testGetAllWithNoKey()
     {
         $this->assertSame(false, $this->db->getAll('InvalidType'));


### PR DESCRIPTION
Previously, it wouldn't throw an error, it would just return null for all queries which was rather confusing ;-)